### PR TITLE
Clean end of markdown filename with regex

### DIFF
--- a/medium_to_jekyll.py
+++ b/medium_to_jekyll.py
@@ -7,6 +7,7 @@ import os
 import requests
 import shutil
 import sys
+import re
 
 def usage():
     print 'Usage: %s <path-to-medium-articles> <path-to-jekyll-root-directory>' % sys.argv[0]
@@ -59,7 +60,7 @@ def format_output_filename(filename):
     # Jekyll expects all seperators to be hyphens
     filename = filename.lower().replace('_', '-')
     # Strip the extra characters Medium has at the end of its URLs
-    return '--'.join(filename.split('--')[:-1]) + '.markdown'
+    return re.sub(r'-*?\w*?\.html$', '', filename) + '.markdown'
 
 def main():
     if len(sys.argv) != 3:


### PR DESCRIPTION
I have several Medium HTML files that end with only a single dash, for example:

```
2018-01-25_Hacking-together-Windows-Hello-on-Ubuntu-ecd97ff16430.html
```

This would result in `format_output_filename` giving all those files the name `.markdown` (a hidden file). By using a more robust regex any number of dashes followed by word characters will be removed, but only at the end of the filename.